### PR TITLE
Clean up `/tmp` in `container-init`

### DIFF
--- a/scripts/bin/container-init
+++ b/scripts/bin/container-init
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Clean up /tmp, just in case there is some leftover files from previous run and `--tmpfs` is not specified.
+# Without this cleanup or `--tmpfs`, the container will no longer start after 10 startups.
+rm -rf /tmp
+mkdir /tmp
+chmod a+rw /tmp
+
 set -eu
 
 # Create additional groups

--- a/scripts/bin/container-init
+++ b/scripts/bin/container-init
@@ -1,12 +1,9 @@
 #!/bin/sh
 
-# Clean up /tmp, just in case there is some leftover files from previous run and `--tmpfs` is not specified.
-# Without this cleanup or `--tmpfs`, the container will no longer start after 10 startups.
-rm -rf /tmp
-mkdir /tmp
-chmod a+rw /tmp
-
 set -eu
+
+# Remove leftover files
+find /tmp/ -mindepth 1 -delete
 
 # Create additional groups
 _IFS=${IFS}; IFS=,


### PR DESCRIPTION
I ran into a problem where the container does not start after 10 startups.

The reason for this is `/tmp/.X10-lock` file are not deleted when running `docker stop`.
On next `docker-start`, `/tmp/.X11-lock` is allocated instead.
This keeps going until `/tmp/.X19-lock` and from that it gives up.

Another workaround is to use `--tmpfs` in `docker run`.
But not all users always use it.